### PR TITLE
Add support for Pale Moon 27.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "Daniel Kamkha",
   "license": "MIT",
   "version": "1.2.0",
+  "engines": {
+    "firefox": ">=38.0a1",
+    "{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}": ">=27.1.0b1"
+   },
   "homepage": "https://github.com/DanielKamkha/PlayPauseFirefox",
   "permissions": {
     "multiprocess": true,


### PR DESCRIPTION
Based on [PMkit documentation draft v1.1](https://github.com/JustOff/pm27-sdk-addons/blob/master/PMkit.md), tested with [Pale Moon 27.1.0beta](https://forum.palemoon.org/viewtopic.php?f=1&t=14455).